### PR TITLE
Fix configure with strict shell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ else
 fi
 
 # Pick an assembler yasm or nasm
-if test x"$AS" == x""; then
+if test x"$AS" = x""; then
   if test x"$yasm_knows_avx512" = x"yes"; then
     AS=yasm
   elif test x"$nasm_knows_avx512" = x"yes"; then


### PR DESCRIPTION
The comparison operator in "test" command is "=", not "==".
Note that the syntax "==" is accepted with Bash.

It was triggering this error message in configure stage:

checking for optional nasm AVX512 support... yes
./configure: 12910: test: x: unexpected operator
Using assembler
Assembler does not understand AVX512 opcodes.  Consider upgrading for best performance.

So the compilation was failing:

  CCAS     md5_mb/md5_mb_mgr_submit_sse.lo
Usage: /home/thomas/projects/dpdk/isa-l/isa-l_crypto/libtool [OPTION]... [MODE-ARG]...
Try 'libtool --help' for more information.
libtool:   error: unrecognised option: '-f'
Makefile:2426: recipe for target 'md5_mb/md5_mb_mgr_submit_sse.lo' failed

Signed-off-by: Thomas Monjalon <thomas.monjalon@6wind.com>