### PR TITLE
Use vmovdqu instead of movdqu in aes_cbc_enc_{128|192|256}_x8 functions

### DIFF
--- a/aes/cbc_enc_128_x8_sb.asm
+++ b/aes/cbc_enc_128_x8_sb.asm
@@ -113,7 +113,7 @@
 %define IV_CNT          (1)
 
 ; instruction set specific operation definitions
-%define MOVDQ         movdqu
+%define MOVDQ         vmovdqu
 %macro PXOR 2
    vpxor %1, %1, %2
 %endm

--- a/aes/cbc_enc_192_x8_sb.asm
+++ b/aes/cbc_enc_192_x8_sb.asm
@@ -111,7 +111,7 @@
 %define PARALLEL_BLOCKS (UNROLLED_LOOPS)
 
 ; instruction set specific operation definitions
-%define MOVDQ         movdqu
+%define MOVDQ         vmovdqu
 %macro PXOR 2
    vpxor %1, %1, %2
 %endm

--- a/aes/cbc_enc_256_x8_sb.asm
+++ b/aes/cbc_enc_256_x8_sb.asm
@@ -111,7 +111,7 @@
 %define PARALLEL_BLOCKS (UNROLLED_LOOPS)
 
 ; instruction set specific operation definitions
-%define MOVDQ         movdqu
+%define MOVDQ         vmovdqu
 %macro PXOR 2
    vpxor %1, %1, %2
 %endm


### PR DESCRIPTION
Using SSE instruction movdqu mixed with AVX instructions in functions above
creates AVX/SSE transitions that carries performance penalties especially
on Skylake processors. Performance can drop up to 6-7 times.

Signed-off-by: Ilmars Poikans <ilmars@delibero.lv>