### PR TITLE
Micro opts: use faster version of F0 in sha1_mb

### DIFF
--- a/md5_mb/md5_mb_x4x2_avx.asm
+++ b/md5_mb/md5_mb_x4x2_avx.asm
@@ -114,8 +114,8 @@ default rel
 %define %%X %2
 %define %%Y %3
 %define %%Z %4
-   ;movdqa   %%F,%%Z
-   vpxor     %%F,%%Z,[ONES]  ; pnot     %%F
+   vpcmpeqd  %%F,%%F,%%F     ; 0xFFFF
+   vpxor     %%F,%%F,%%Z  ; pnot     %%Z
    vpor      %%F,%%F,%%X
    vpxor     %%F,%%F,%%Y
 %endmacro
@@ -777,6 +777,3 @@ MD5_TABLE:
 	dd	0xbd3af235, 0xbd3af235, 0xbd3af235, 0xbd3af235
 	dd	0x2ad7d2bb, 0x2ad7d2bb, 0x2ad7d2bb, 0x2ad7d2bb
 	dd	0xeb86d391, 0xeb86d391, 0xeb86d391, 0xeb86d391
-
-ONES:
-	dd	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff

--- a/md5_mb/md5_mb_x4x2_sse.asm
+++ b/md5_mb/md5_mb_x4x2_sse.asm
@@ -116,8 +116,8 @@ default rel
 %define %%X %2
 %define %%Y %3
 %define %%Z %4
-        movdqa  %%F,%%Z
-        pxor    %%F,[ONES]  ; pnot     %%F
+        pcmpeqd %%F,%%F
+        pxor    %%F,%%Z  ; pnot     %%Z
         por     %%F,%%X
         pxor    %%F,%%Y
 %endmacro
@@ -773,6 +773,3 @@ MD5_TABLE:
         dd      0xbd3af235, 0xbd3af235, 0xbd3af235, 0xbd3af235
         dd      0x2ad7d2bb, 0x2ad7d2bb, 0x2ad7d2bb, 0x2ad7d2bb
         dd      0xeb86d391, 0xeb86d391, 0xeb86d391, 0xeb86d391
-
-ONES:
-        dd      0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff

--- a/md5_mb/md5_mb_x8x2_avx2.asm
+++ b/md5_mb/md5_mb_x8x2_avx2.asm
@@ -265,7 +265,8 @@ rot44 equ  21
 %define %%X %2
 %define %%Y %3
 %define %%Z %4
-   vpxor     %%F,%%Z,[ONES]  ; pnot     %%F
+   vpcmpeqd  %%F,%%F,%%F     ; 0xFFFF
+   vpxor     %%F,%%F,%%Z  ; pnot     %%Z
    vpor      %%F,%%F,%%X
    vpxor     %%F,%%F,%%Y
 %endmacro
@@ -913,5 +914,3 @@ MD5_TABLE:
 	dd	0x2ad7d2bb, 0x2ad7d2bb, 0x2ad7d2bb, 0x2ad7d2bb
 	dd	0xeb86d391, 0xeb86d391, 0xeb86d391, 0xeb86d391
 	dd	0xeb86d391, 0xeb86d391, 0xeb86d391, 0xeb86d391
-ONES:	dd	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
-	dd	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff

--- a/sha1_mb/sha1_mb_x4_avx.asm
+++ b/sha1_mb/sha1_mb_x4_avx.asm
@@ -73,16 +73,16 @@ default rel
 ;;
 ;; Magic functions defined in FIPS 180-1
 ;;
-; macro MAGIC_F0 F,B,C,D,T   ;; F = (D ^ (B & (C ^ D)))
+; macro MAGIC_F0 F,B,C,D,T   ;; F = ((B & C) | ((~ B) & D) )
 %macro MAGIC_F0 5
 %define %%regF %1
 %define %%regB %2
 %define %%regC %3
 %define %%regD %4
 %define %%regT %5
-    vpxor  %%regF, %%regC,%%regD
-    vpand  %%regF, %%regF,%%regB
-    vpxor  %%regF, %%regF,%%regD
+    vpand  %%regF, %%regB,%%regC
+    vpandn %%regT, %%regB,%%regD
+    vpor   %%regF, %%regT,%%regF
 %endmacro
 
 ; macro MAGIC_F1 F,B,C,D,T   ;; F = (B ^ C ^ D)

--- a/sha1_mb/sha1_mb_x4_sse.asm
+++ b/sha1_mb/sha1_mb_x4_sse.asm
@@ -77,17 +77,18 @@ default rel
 ;;
 ;; Magic functions defined in FIPS 180-1
 ;;
-; macro MAGIC_F0 F,B,C,D,T   ;; F = (D ^ (B & (C ^ D)))
+; macro MAGIC_F0 F,B,C,D,T   ;; F = ((B & C) | ((~ B) & D))
 %macro MAGIC_F0 5
 %define %%regF %1
 %define %%regB %2
 %define %%regC %3
 %define %%regD %4
 %define %%regT %5
-    movdqa  %%regF,%%regC
-    pxor  %%regF,%%regD
-    pand  %%regF,%%regB
-    pxor  %%regF,%%regD
+    movdqa %%regF, %%regB
+    movdqa %%regT, %%regB
+    pand  %%regF, %%regC
+    pandn %%regT, %%regD
+    por   %%regF, %%regF
 %endmacro
 
 ; macro MAGIC_F1 F,B,C,D,T   ;; F = (B ^ C ^ D)

--- a/sha1_mb/sha1_mb_x4_sse.asm
+++ b/sha1_mb/sha1_mb_x4_sse.asm
@@ -88,7 +88,7 @@ default rel
     movdqa %%regT, %%regB
     pand  %%regF, %%regC
     pandn %%regT, %%regD
-    por   %%regF, %%regF
+    por   %%regF, %%regT
 %endmacro
 
 ; macro MAGIC_F1 F,B,C,D,T   ;; F = (B ^ C ^ D)

--- a/sha1_mb/sha1_mb_x4_sse.asm
+++ b/sha1_mb/sha1_mb_x4_sse.asm
@@ -84,11 +84,10 @@ default rel
 %define %%regC %3
 %define %%regD %4
 %define %%regT %5
-    movdqa %%regF, %%regB
-    movdqa %%regT, %%regB
-    pand  %%regF, %%regC
-    pandn %%regT, %%regD
-    por   %%regF, %%regT
+    movdqa  %%regF,%%regC
+    pxor  %%regF,%%regD
+    pand  %%regF,%%regB
+    pxor  %%regF,%%regD
 %endmacro
 
 ; macro MAGIC_F1 F,B,C,D,T   ;; F = (B ^ C ^ D)

--- a/sha1_mb/sha1_mb_x8_avx2.asm
+++ b/sha1_mb/sha1_mb_x8_avx2.asm
@@ -112,16 +112,16 @@ default rel
 ;;
 ;; Magic functions defined in FIPS 180-1
 ;;
-;MAGIC_F0 MACRO regF:REQ,regB:REQ,regC:REQ,regD:REQ,regT:REQ ;; ((D ^ (B & (C ^ D)))
+;MAGIC_F0 MACRO regF:REQ,regB:REQ,regC:REQ,regD:REQ,regT:REQ ;; F0 = ((B & C) | ((~B) & D))
 %macro MAGIC_F0 5
 %define %%regF %1
 %define %%regB %2
 %define %%regC %3
 %define %%regD %4
 %define %%regT %5
-    vpxor  %%regF, %%regC,%%regD
-    vpand  %%regF, %%regF,%%regB
-    vpxor  %%regF, %%regF,%%regD
+    vpand  %%regF, %%regB,%%regC
+    vpandn %%regT, %%regB,%%regD
+    vpor   %%regF, %%regT,%%regF
 %endmacro
 
 ;MAGIC_F1 MACRO regF:REQ,regB:REQ,regC:REQ,regD:REQ,regT:REQ ;; (B ^ C ^ D)


### PR DESCRIPTION
I've noticed that the multibyte version of SHA1 also uses the less parallel version of F0, so we can switch that to the ANDN variant too.
Also the MD5 uses a mask of all ones to work around the lack of PNOT instruction, so generate that on the fly with one instruction instead of loading it from memory on each iteration.